### PR TITLE
Enable manual triggering of KiCad export workflow

### DIFF
--- a/.github/workflows/kicad-exports.yml
+++ b/.github/workflows/kicad-exports.yml
@@ -17,8 +17,6 @@ on:
       - '*-*/README.md'
       - '.github/workflows/kicad-exports.yml'
       - '.kibot/**'
-  milestone:
-    types: [opened, deleted]
   workflow_dispatch:
     inputs:
       git-ref:
@@ -40,17 +38,23 @@ jobs:
       - name: Check changed files
         id: diff
         run: |
+          echo "Event:"
+          echo "${{toJson(github.event)}}"
+          echo
           # See https://github.community/t/check-pushed-file-changes-with-git-diff-tree-in-github-actions/17220/10
           if [ $GITHUB_BASE_REF ]; then
             # Pull Request
             git fetch origin $GITHUB_BASE_REF --depth=1
             export DIFF=$( git diff --name-only origin/$GITHUB_BASE_REF $GITHUB_SHA )
             echo "Diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA:"
-          else
+          elif [ ${{github.event.before}} != "0000000000000000000000000000000000000000" ]; then
             # Push
             git fetch origin ${{ github.event.before }} --depth=1
             export DIFF=$( git diff --name-only ${{ github.event.before }} $GITHUB_SHA )
             echo "Diff between ${{ github.event.before }} and $GITHUB_SHA:"
+          else
+            # Manual
+            export DIFF=$( ls -d */ )
           fi
           echo "$DIFF"
           # Treat all directories as changed if this workflow is changed

--- a/.github/workflows/kicad-exports.yml
+++ b/.github/workflows/kicad-exports.yml
@@ -22,6 +22,9 @@ on:
       git-ref:
         description: 'Git ref (optional)'
         required: false
+      boards:
+        description: 'Boards (optional)'
+        required: false
 
 jobs:
   # Find changed boards
@@ -32,29 +35,39 @@ jobs:
       boards: ${{steps.set-boards.outputs.boards}}
       numboards: ${{steps.set-boards.outputs.numboards}}
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (latest)
         uses: actions/checkout@v2
+        if: github.event.inputs.git-ref == ''
+
+      - name: Checkout repository (custom)
+        uses: actions/checkout@v2
+        if: github.event.inputs.git-ref != ''
+        with:
+          ref: ${{github.event.inputs.git-ref}}
 
       - name: Check changed files
         id: diff
         run: |
-          echo "Event:"
-          echo "${{toJson(github.event)}}"
-          echo
           # See https://github.community/t/check-pushed-file-changes-with-git-diff-tree-in-github-actions/17220/10
+          MISSING_REF="0000000000000000000000000000000000000000"
           if [ $GITHUB_BASE_REF ]; then
             # Pull Request
             git fetch origin $GITHUB_BASE_REF --depth=1
             export DIFF=$( git diff --name-only origin/$GITHUB_BASE_REF $GITHUB_SHA )
             echo "Diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA:"
-          elif [ ${{github.event.before}} != "0000000000000000000000000000000000000000" ]; then
+          elif [ -n "${{github.event.before}}" ] && [ "${{github.event.before}}" != $MISSING_REF ]; then
             # Push
             git fetch origin ${{ github.event.before }} --depth=1
             export DIFF=$( git diff --name-only ${{ github.event.before }} $GITHUB_SHA )
             echo "Diff between ${{ github.event.before }} and $GITHUB_SHA:"
           else
             # Manual
-            export DIFF=$( ls -d */ )
+            if [ -n "${{github.event.inputs.boards}}" ]; then
+              export DIFF=$(echo "${{github.event.inputs.boards}}" | tr " " "\n" | sed -e 's/$/\//')
+              echo "Manually selected boards:"
+            else
+              export DIFF=$( ls -d */ )
+            fi
           fi
           echo "$DIFF"
           # Treat all directories as changed if this workflow is changed
@@ -119,8 +132,15 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (latest)
         uses: actions/checkout@v2
+        if: github.event.inputs.git-ref == ''
+
+      - name: Checkout repository (custom)
+        uses: actions/checkout@v2
+        if: github.event.inputs.git-ref != ''
+        with:
+          ref: ${{github.event.inputs.git-ref}}
 
       - name: Get current date
         id: date

--- a/.github/workflows/kicad-exports.yml
+++ b/.github/workflows/kicad-exports.yml
@@ -146,6 +146,13 @@ jobs:
         id: date
         run: echo "::set-output name=today::$(date +'%Y%m%d')"
 
+      - name: Check directory name
+        run: |
+          if [ ! -d "${{matrix.board}}" ]; then
+            echo "Directory ${{matrix.board}} doesn't exist!"
+            exit 1
+          fi
+
       - name: Check schematic and layout file names
         working-directory: ${{matrix.board}}
         run: |


### PR DESCRIPTION
This PR improves the KiCad export workflow on Github Actions by:

- Adding error-handling to hopefully make the workflow work correctly on squash-and-merge commits onto develop
- Making it possible to manually run the workflow on a particular Git ref (branch name, tag name, or commit SHA hash)
- Making it possible to specify which boards to export